### PR TITLE
Latex extension

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,7 @@
+LaTeX Support
+==============
+
+If you want to enter LaTeX code and have it rendered, you need to install
+the texlive extension, e.g.
+
+    flatpak install flathub org.freedesktop.Sdk.Extension.texlive

--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -4,6 +4,16 @@ runtime-version: '19.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
     - org.freedesktop.Sdk.Extension.texlive
+
+add-extensions:
+  org.freedesktop.Sdk.Extension.texlive:
+    directory: extensions
+    subdirectories: true
+    no-autodownload: true
+    autodelete: true
+    version: "19.08"
+
+
 command: xournalpp
 finish-args:
   # X11 + XShm access
@@ -23,7 +33,7 @@ finish-args:
   - "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
   - "--persist=.xournalpp"
   # Access to the TeX binaries, taken from https://github.com/flathub/org.texstudio.TeXstudio/blob/d4e27005d20889aa738da129ea6b6b0e5c0a0528/org.texstudio.TeXstudio.yaml#L22
-  - --env=PATH=/app/jre/bin:/usr/bin:/app/bin:/app/bin/x86_64-linux
+  - --env=PATH=/app/bin:/app/extensions/bin:/app/extensions/bin/x86_64-linux:/usr/bin/
   
 cleanup:
   - "/include"

--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -47,6 +47,7 @@ cleanup:
   - "*.a"
 modules:
   - name: texlive
+    disabled: true
     buildsystem: simple
     build-commands:
         - /usr/lib/sdk/texlive/install.sh

--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -2,8 +2,6 @@ app-id: com.github.xournalpp.xournalpp
 runtime: org.freedesktop.Platform
 runtime-version: '19.08'
 sdk: org.freedesktop.Sdk
-sdk-extensions:
-    - org.freedesktop.Sdk.Extension.texlive
 
 add-extensions:
   org.freedesktop.Sdk.Extension.texlive:
@@ -46,12 +44,6 @@ cleanup:
   - "*.la"
   - "*.a"
 modules:
-  - name: texlive
-    disabled: true
-    buildsystem: simple
-    build-commands:
-        - /usr/lib/sdk/texlive/install.sh
-
   - name: poppler
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
This change makes the LaTeX support optional. Once this change is applied, you need to install the extension in order to see the LaTeX binaries.