### PR TITLE
Update to 1.0.20

### DIFF
--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -104,5 +104,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/xournalpp/xournalpp
-        commit: d376e7a6aebc0f92a81af7d2da2090d050434262
-        tag: 1.0.19
+        commit: 09ec4999f56a5077c9c2312eb390be9d26cb24b9
+        tag: 1.0.20


### PR DESCRIPTION
The commit ID 09ec4999f56a5077c9c2312eb390be9d26cb24b9 is the ID of the latest commit before Xournal++ version 1.0.20 was released.