### PR TITLE
Make Font size migration plugin require Gtk 3

### DIFF
--- a/0003-ensure-lgi-loads-Gtk-3.patch
+++ b/0003-ensure-lgi-loads-Gtk-3.patch
@@ -1,0 +1,25 @@
+From 34a35dcb832fc7311b687c23a8561b7d223206f3 Mon Sep 17 00:00:00 2001
+From: rolandlo <roland_loetscher@hotmail.com>
+Date: Wed, 29 Sep 2021 21:22:12 +0200
+Subject: [PATCH] ensure lgi loads Gtk 3
+
+---
+ plugins/MigrateFontSizes/main.lua | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins/MigrateFontSizes/main.lua b/plugins/MigrateFontSizes/main.lua
+index 8c243b32..02dceb91 100644
+--- a/plugins/MigrateFontSizes/main.lua
++++ b/plugins/MigrateFontSizes/main.lua
+@@ -27,7 +27,7 @@ function showDialog()
+   end
+ 
+   --lgi module has been found
+-  local Gtk = lgi.Gtk
++  local Gtk = lgi.require("Gtk", "3.0")
+   local Gdk = lgi.Gdk
+   local assert = lgi.assert
+   local builder = Gtk.Builder()
+-- 
+2.32.0
+

--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -132,3 +132,5 @@ modules:
         path: 0001-Update-appdata-screenshots.patch
       - type: patch
         path: 0002-Avoid-deprecated-mimetypes-tag.patch
+      - type: patch
+        path: 0003-ensure-lgi-loads-Gtk-3.patch


### PR DESCRIPTION
This commit makes the Font size migration plugin work with the Gnome 41 runtime by making it require Gtk 3 explicitly (instead of the latest Gtk version). See https://github.com/pavouk/lgi/issues/274#issuecomment-930266215 for an explanation of why this is required.