### PR TITLE
Added access to network shares

### DIFF
--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -30,6 +30,9 @@ finish-args:
   - --talk-name=ca.desrt.dconf
   - --env=DCONF_USER_CONFIG_DIR=.config/dconf
   - --persist=.xournalpp
+  # Allow acces to GVFS (network shares)
+  - --filesystem=xdg-run/gvfs
+  - --talk-name=org.gtk.vfs.*
   # Access to the TeX binaries, taken from https://github.com/flathub/org.texstudio.TeXstudio/blob/d4e27005d20889aa738da129ea6b6b0e5c0a0528/org.texstudio.TeXstudio.yaml#L22
   - --env=PATH=/app/bin:/app/extensions/bin:/app/extensions/bin/x86_64-linux:/app/extensions/bin/aarch64-linux:/usr/bin/
 

--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -30,8 +30,9 @@ finish-args:
   - --talk-name=ca.desrt.dconf
   - --env=DCONF_USER_CONFIG_DIR=.config/dconf
   - --persist=.xournalpp
-  # Allow acces to GVFS (network shares)
+  # Allow acces to GVfs (network shares)
   - --filesystem=xdg-run/gvfs
+  - --filesystem=xdg-run/gvfsd
   - --talk-name=org.gtk.vfs.*
   # Access to the TeX binaries, taken from https://github.com/flathub/org.texstudio.TeXstudio/blob/d4e27005d20889aa738da129ea6b6b0e5c0a0528/org.texstudio.TeXstudio.yaml#L22
   - --env=PATH=/app/bin:/app/extensions/bin:/app/extensions/bin/x86_64-linux:/app/extensions/bin/aarch64-linux:/usr/bin/


### PR DESCRIPTION
The current version does not allow Xournal++ to access files on network shares.

This pull request provides support for access to network shares mounted using GVfs.