### PR TITLE
Add poppler-data

### DIFF
--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -80,6 +80,15 @@ modules:
           project-id: 3686
           url-template: https://poppler.freedesktop.org/poppler-$version.tar.xz
 
+  - name: poppler-data
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    sources:
+      - type: archive
+        url: https://poppler.freedesktop.org/poppler-data-0.4.11.tar.gz
+        sha256: 2cec05cd1bb03af98a8b06a1e22f6e6e1a65b1e2f3816cb3069bb0874825f08c
+          
   - name: libzip
     buildsystem: cmake-ninja
     config-opts:

--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -88,7 +88,11 @@ modules:
       - type: archive
         url: https://poppler.freedesktop.org/poppler-data-0.4.11.tar.gz
         sha256: 2cec05cd1bb03af98a8b06a1e22f6e6e1a65b1e2f3816cb3069bb0874825f08c
-          
+        x-checker-data:
+          type: anitya
+          project-id: 3687
+          url-template: https://poppler.freedesktop.org/poppler-data-$version.tar.gz
+                         
   - name: libzip
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
Poppler encoding data `poppler-data` should be included according to [the poppler website](https://poppler.freedesktop.org/). We forgot about that until now. It does make a difference, as my tests show. As a test document the one from https://github.com/xournalpp/xournalpp/issues/3474 can be used. The Chinese characters (in the table of contents) only show up when `poppler-data` is included (like in this PR).