### PR TITLE
Change socket to fallback-x11 to fix "Unsafe" warning

### DIFF
--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -16,7 +16,7 @@ command: xournalpp
 finish-args:
   # X11 + XShm access
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
   # Wayland access
   - --socket=wayland
   # File access (unfortunately, autosaving will not work properly outside of $XDG_DOCUMENTS_DIR)


### PR DESCRIPTION
Using `--socket=x11` results in GNOME Software showing the app as "Unsafe. Uses a legacy windowing system." Changing this to `--socket=fallback-x11` lets app run on Wayland, but can use X11 if Wayland not available