### PR TITLE
Add pipewire support

### DIFF
--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -24,6 +24,7 @@ finish-args:
   - --filesystem=host
   # Sound
   - --socket=pulseaudio
+  - --filesystem=xdg-run/pipewire-0
   # Allow dconf
   - --filesystem=xdg-run/dconf
   - --filesystem=~/.config/dconf:ro


### PR DESCRIPTION
Currently the flatpak lacks pipewire audio recording support.
This fixes it hopefully.

`flatpak --user override --filesystem=xdg-run/pipewire-0 com.github.xournalpp.xournalpp`