### PR TITLE
Build xournalpp in RelWithDebInfo mode

### DIFF
--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -153,6 +153,8 @@ modules:
 
   - name: xournalpp
     buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     builddir: true
     sources:
       - type: git


### PR DESCRIPTION
The official releases are built with the `RelWithDebInfo` build type. It should be the same for the flatpak. Otherwise the Debug build type is used, which has unwanted effects (like slowing down the app and crashing on failing asserts).