### PR TITLE
Build poppler with libopenjpeg support

### DIFF
--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -74,6 +74,22 @@ modules:
         url: https://github.com/pavouk/lgi.git
         commit: 4071f902b635d3a7078c65162fce347367b1371d
 
+  - name: openjpeg
+    buildsystem: cmake-ninja
+    cleanup:
+      - /bin
+      - /include
+      - /lib/openjpeg-*
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://www.github.com/uclouvain/openjpeg/archive/v2.5.0.tar.gz
+        sha256: 0333806d6adecc6f7a91243b2b839ff4d2053823634d4f6ed7a59bc87409122a
+        x-checker-data:
+          type: anitya
+          project-id: 2550
+          url-template: https://www.github.com/uclouvain/openjpeg/archive/v$version.tar.gz
+
   - name: poppler
     buildsystem: cmake-ninja
     config-opts:
@@ -81,8 +97,9 @@ modules:
       - -DCMAKE_INSTALL_INCLUDEDIR=/app/include
       - -DENABLE_QT5=OFF
       - -DENABLE_QT6=OFF
+      - -DENABLE_CPP=OFF
       - -DENABLE_BOOST=OFF
-      - -DENABLE_LIBOPENJPEG=none
+      - -DENABLE_LIBOPENJPEG=openjpeg2
     cleanup:
       - /bin
     sources:


### PR DESCRIPTION
Fixes https://github.com/xournalpp/xournalpp/issues/2568

Some images from PDFs were rendered as black boxes because the flatpak's `poppler` didn't have `libopenjpeg` baked into it. With this PR it works. This can be tested with the file from https://github.com/xournalpp/xournalpp/issues/2568#issue-771415083